### PR TITLE
Use HTML DOM Node functions instead of Strings

### DIFF
--- a/src/web/js/client.js
+++ b/src/web/js/client.js
@@ -73,14 +73,25 @@ $(function() {
 });
 
 function fillSelect(element, values, transform) {
+    element = element[0];
     var html = "";
-    html += "<option value=\"All\">All</option>";
-    html += "<option value=\"Average\">Average</option>";
+    var createOption = function(name, value) {
+        var opt = document.createElement('option');
+        opt.innerHTML = name;
+        var val = value === undefined ? name : value;
+        opt.value = val;
+        return opt;
+    }
+    var all = createOption("All");
+    var avg = createOption("Average");
+    // debugger;
+    element.appendChild(all);
+    element.appendChild(avg);
     if (transform == null) { transform = function(val) { return val; } }
     for (var i = 0; i < values.length; i++) {
-        html += "<option value=\"" + values[i] + "\">" + transform(values[i]) + "</option>";
+        var opt = createOption(transform(values[i]), values[i]);
+        element.appendChild(opt);
     }
-    element.append(html);
 }
 
 function populateTable(callback) {

--- a/src/web/js/client.js
+++ b/src/web/js/client.js
@@ -77,7 +77,7 @@ function fillSelect(element, values, transform) {
     var html = "";
     var createOption = function(name, value) {
         var opt = document.createElement('option');
-        opt.innerHTML = name;
+        opt.textContent = name;
         var val = value === undefined ? name : value;
         opt.value = val;
         return opt;


### PR DESCRIPTION
Saw this program on /r/wpi and it ended up being really helpful :+1: 

Writing HTML Strings in JavaScript is a lot slower since the DOM has to parse the HTML and then  add it to the Document tree. Functions like `createElement` and `appendChild` are heavily optimized and skip the entire parsing step since it's clear to the browser exactly what the intent is. 

This is beneficial because this program is populated from a particularly large JSON file. After deploying and running both versions of the site this loads the actual interface a lot faster. 

There are other areas of the code where using this style of HTML creation would be a lot faster (particularly the rendering of the table) however that fix is more dependent on your implementation of the program and I figured it'd be best to let you make a decision on that. However creating `<tr>` and `<td>`s with this method will drastically lower rendering/processing times given the large size of the JSON source file.

Food for thought. Thanks again for the helpful service.
